### PR TITLE
Optimize serialization and deserialization

### DIFF
--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -13,6 +13,7 @@ log = { version = "0.4", default-features = false }
 primitive-types = { version = "0.7", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "rc"], optional = true }
+serde_bytes = { version = "0.11.5", optional = true }
 
 [dev-dependencies]
 hex = "0.4"
@@ -20,5 +21,5 @@ hex = "0.4"
 [features]
 default = ["std"]
 with-codec = ["codec", "primitive-types/impl-codec"]
-with-serde = ["serde", "primitive-types/impl-serde"]
+with-serde = ["serde", "serde_bytes", "primitive-types/impl-serde"]
 std = ["primitive-types/std", "log/std", "codec/std", "serde/std"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 log = { version = "0.4", default-features = false }
 primitive-types = { version = "0.7", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
-serde = { version = "1.0", default-features = false, features = ["derive", "rc"], optional = true }
+serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
 
 [dev-dependencies]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -33,8 +33,10 @@ use crate::eval::{eval, Control};
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Machine {
 	/// Program data.
+	#[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
 	data: Rc<Vec<u8>>,
 	/// Program code.
+	#[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
 	code: Rc<Vec<u8>>,
 	/// Program counter.
 	position: Result<usize, ExitReason>,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -24,7 +24,6 @@ pub use crate::error::{Trap, Capture, ExitReason, ExitSucceed, ExitError, ExitRe
 
 use core::ops::Range;
 use alloc::vec::Vec;
-use alloc::rc::Rc;
 use primitive_types::U256;
 use crate::eval::{eval, Control};
 
@@ -34,10 +33,10 @@ use crate::eval::{eval, Control};
 pub struct Machine {
 	/// Program data.
 	#[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
-	data: Rc<Vec<u8>>,
+	data: Vec<u8>,
 	/// Program code.
 	#[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
-	code: Rc<Vec<u8>>,
+	code: Vec<u8>,
 	/// Program counter.
 	position: Result<usize, ExitReason>,
 	/// Return value.
@@ -62,8 +61,8 @@ impl Machine {
 
 	/// Create a new machine with given code and data.
 	pub fn new(
-		code: Rc<Vec<u8>>,
-		data: Rc<Vec<u8>>,
+		code: Vec<u8>,
+		data: Vec<u8>,
 		stack_limit: usize,
 		memory_limit: usize
 	) -> Self {

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -9,6 +9,7 @@ use crate::{ExitError, ExitFatal};
 #[cfg_attr(feature = "with-codec", derive(codec::Encode, codec::Decode))]
 #[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Memory {
+	#[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
 	data: Vec<u8>,
 	effective_len: U256,
 	limit: usize,

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,9 +14,10 @@ primitive-types = { version = "0.7", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde_bytes = { version = "0.11.5", optional = true }
 
 [features]
 default = ["std"]
 with-codec = ["codec", "primitive-types/impl-codec"]
-with-serde = ["serde", "primitive-types/impl-serde"]
+with-serde = ["serde", "serde_bytes", "primitive-types/impl-serde"]
 std = ["evm-core/std", "primitive-types/std", "sha3/std"]

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -266,7 +266,7 @@ pub fn create<H: Handler>(
 		}
 	};
 
-	match handler.create(runtime.context.address, scheme, value, &code, None) {
+	match handler.create(runtime.context.address, scheme, value, code, None) {
 		Capture::Exit((reason, address, return_data)) => {
 			save_created_address(runtime, reason, address, return_data, handler)
 		},

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -76,7 +76,7 @@ pub trait Handler {
 		caller: H160,
 		scheme: CreateScheme,
 		value: U256,
-		init_code: &Vec<u8>,
+		init_code: Vec<u8>,
 		target_gas: Option<usize>,
 	) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Self::CreateInterrupt>;
 	/// Feed in create feedback.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -82,10 +82,11 @@ macro_rules! step {
 pub struct Runtime<'config> {
 	machine: Machine,
 	status: Result<(), ExitReason>,
+	#[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
 	return_data_buffer: Vec<u8>,
 	context: Context,
-	#[serde(skip)]
-	#[serde(default = "Config::default")]
+	#[cfg_attr(feature = "with-serde", serde(skip))]
+	#[cfg_attr(feature = "with-serde", serde(default = "Config::default"))]
 	_config: &'config Config,
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -20,7 +20,6 @@ pub use crate::handler::{Transfer, Handler};
 pub use crate::eval::{save_return_value, save_created_address, Control};
 
 use alloc::vec::Vec;
-use alloc::rc::Rc;
 
 macro_rules! step {
 	( $self:expr, $handler:expr, $return:tt $($err:path)?; $($ok:path)? ) => ({
@@ -93,8 +92,8 @@ pub struct Runtime<'config> {
 impl<'config> Runtime<'config> {
 	/// Create a new runtime with given code and data.
 	pub fn new(
-		code: Rc<Vec<u8>>,
-		data: Rc<Vec<u8>>,
+		code: Vec<u8>,
+		data: Vec<u8>,
 		context: Context,
 		config: &'config Config,
 	) -> Self {

--- a/src/executor/stack.rs
+++ b/src/executor/stack.rs
@@ -1,6 +1,5 @@
 use core::convert::Infallible;
 use core::cmp::min;
-use alloc::rc::Rc;
 use alloc::vec::Vec;
 use alloc::collections::{BTreeMap, BTreeSet};
 use primitive_types::{U256, H256, H160};
@@ -152,7 +151,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 		&mut self,
 		caller: H160,
 		value: U256,
-		init_code: &Vec<u8>,
+		init_code: Vec<u8>,
 		gas_limit: usize,
 	) -> ExitReason {
 //		let transaction_cost = gasometer::create_transaction_cost(&init_code);
@@ -179,7 +178,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 		&mut self,
 		caller: H160,
 		value: U256,
-		init_code: &Vec<u8>,
+		init_code: Vec<u8>,
 		salt: H256,
 		gas_limit: usize,
 	) -> ExitReason {
@@ -188,7 +187,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 //			Ok(()) => (),
 //			Err(e) => return e.into(),
 //		}
-		let code_hash = keccak256_digest(init_code); //H256::from_slice(Keccak256::digest(&init_code).as_slice());
+		let code_hash = keccak256_digest(&init_code); //H256::from_slice(Keccak256::digest(&init_code).as_slice());
 
 		match self.create_inner(
 			caller,
@@ -356,7 +355,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 		caller: H160,
 		scheme: CreateScheme,
 		value: U256,
-		init_code: &Vec<u8>,
+		init_code: Vec<u8>,
 		target_gas: Option<usize>,
 		take_l64: bool,
 	) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Infallible> {
@@ -445,8 +444,8 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 		}
 
 		let mut runtime = Runtime::new(
-			Rc::new(init_code.to_vec()),
-			Rc::new(Vec::new()),
+			init_code,
+			Vec::new(),
 			context,
 			self.config,
 		);
@@ -599,8 +598,8 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 		}
 
 		let mut runtime = Runtime::new(
-			Rc::new(code),
-			Rc::new(input),
+			code,
+			input,
 			context,
 			self.config,
 		);
@@ -768,7 +767,7 @@ impl<'backend, 'config, B: Backend> Handler for StackExecutor<'backend, 'config,
 		caller: H160,
 		scheme: CreateScheme,
 		value: U256,
-		init_code: &Vec<u8>,
+		init_code: Vec<u8>,
 		target_gas: Option<usize>,
 	) -> Capture<(ExitReason, Option<H160>, Vec<u8>), Self::CreateInterrupt> {
 		self.create_inner(caller, scheme, value, init_code, target_gas, true)


### PR DESCRIPTION
- Use `serde_bytes` to enable optimized handling of `Vec<u8>`
- Remove `Rc` and hidden vector copies

With these changes, the number of instructions required for serialization and deserialization has been reduced by 20 times.