### PR TITLE
#187 code copy elimination

### DIFF
--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -1,0 +1,40 @@
+use alloc::vec::Vec;
+use core::ops::Deref;
+use primitive_types::H160;
+
+/// Contract code
+#[derive(Clone, Debug)]
+#[cfg_attr(feature = "with-codec", derive(codec::Encode, codec::Decode))]
+#[cfg_attr(feature = "with-serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum Code {
+    /// Account reference
+    AccountRef {
+        /// pointer to the code data
+        #[cfg_attr(feature = "with-serde", serde(skip))]
+        #[cfg_attr(feature = "with-serde", serde(default = "core::ptr::null"))]
+        ptr: *const u8,
+
+        /// code size
+        #[cfg_attr(feature = "with-serde", serde(skip))]
+        len: usize,
+
+        /// code account
+        account: H160,
+    },
+    /// Owned code
+    Vec {
+        /// Code storage
+        #[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
+        code: Vec<u8>,
+    },
+}
+
+impl Deref for Code {
+    type Target = [u8];
+    fn deref(&self) -> &[u8] {
+        match self {
+            Code::AccountRef { ptr, len, .. } => unsafe { core::slice::from_raw_parts(*ptr, *len) },
+            Code::Vec { code } => &code[..],
+        }
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,7 @@
 extern crate core;
 extern crate alloc;
 
+mod code;
 mod memory;
 mod stack;
 mod valids;
@@ -16,6 +17,7 @@ mod error;
 mod eval;
 mod utils;
 
+pub use crate::code::Code;
 pub use crate::memory::Memory;
 pub use crate::stack::Stack;
 pub use crate::valids::Valids;
@@ -35,8 +37,7 @@ pub struct Machine {
 	#[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
 	data: Vec<u8>,
 	/// Program code.
-	#[cfg_attr(feature = "with-serde", serde(with = "serde_bytes"))]
-	code: Vec<u8>,
+	code: Code,
 	/// Program counter.
 	position: Result<usize, ExitReason>,
 	/// Return value.
@@ -58,10 +59,14 @@ impl Machine {
 	pub fn memory(&self) -> &Memory { &self.memory }
 	/// Mutable reference of machine memory.
 	pub fn memory_mut(&mut self) -> &mut Memory { &mut self.memory }
+	/// Reference of machine code.
+	pub fn code(&self) -> &Code { &self.code }
+	/// Mutable reference of machine code.
+	pub fn code_mut(&mut self) -> &mut Code { &mut self.code }
 
 	/// Create a new machine with given code and data.
 	pub fn new(
-		code: Vec<u8>,
+		code: Code,
 		data: Vec<u8>,
 		stack_limit: usize,
 		memory_limit: usize

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 use primitive_types::{H160, H256, U256};
 use crate::{Capture, Stack, ExitError, Opcode, ExternalOpcode,
-			CreateScheme, Context, Machine, ExitReason};
+			CreateScheme, Context, Machine, ExitReason, Code};
 
 /// Transfer from source to target, with given value.
 #[derive(Clone, Debug)]
@@ -32,7 +32,7 @@ pub trait Handler {
 	/// Get code hash of address.
 	fn code_hash(&self, address: H160) -> H256;
 	/// Get code of address.
-	fn code(&self, address: H160) -> Vec<u8>;
+	fn code(&self, address: H160) -> Code;
 	/// Get storage value of address at index.
 	fn storage(&self, address: H160, index: U256) -> U256;
 	/// Get original storage value of address at index.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -92,7 +92,7 @@ pub struct Runtime<'config> {
 impl<'config> Runtime<'config> {
 	/// Create a new runtime with given code and data.
 	pub fn new(
-		code: Vec<u8>,
+		code: Code,
 		data: Vec<u8>,
 		context: Context,
 		config: &'config Config,
@@ -104,6 +104,16 @@ impl<'config> Runtime<'config> {
 			context,
 			_config: config,
 		}
+	}
+
+	/// Restore code data
+	pub fn finalize_restore<H: Handler>(&mut self, handler: &H) {
+		let code_account = match self.machine.code() {
+			Code::AccountRef{ptr: _, len: _, account} => *account,
+			_ => return
+		};
+
+		*self.machine.code_mut() = handler.code(code_account);
 	}
 
 	/// Get return data

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -5,7 +5,7 @@ use primitive_types::{H160, H256, U256};
 use sha3::{Digest, Keccak256};
 use super::{Basic, Backend, ApplyBackend, Apply, Log};
 use evm_runtime::CreateScheme;
-use crate::{Capture, Transfer, ExitReason};
+use crate::{Capture, Transfer, ExitReason, Code};
 
 fn keccak256_digest(data: &[u8]) -> H256 {
     H256::from_slice(Keccak256::digest(&data).as_slice())
@@ -118,8 +118,8 @@ impl<'vicinity> Backend for MemoryBackend<'vicinity> {
 		self.state.get(&address).map(|v| v.code.len()).unwrap_or(0)
 	}
 
-	fn code(&self, address: H160) -> Vec<u8> {
-		self.state.get(&address).map(|v| v.code.clone()).unwrap_or_default()
+	fn code(&self, address: H160) -> Code {
+		Code::Vec{ code: self.state.get(&address).map(|v| v.code.clone()).unwrap_or_default() }
 	}
 
 	fn storage(&self, address: H160, index: U256) -> U256 {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -11,7 +11,7 @@ use alloc::vec::Vec;
 use core::convert::Infallible;
 use primitive_types::{H160, H256, U256};
 use evm_runtime::CreateScheme;
-use crate::{Capture, Transfer, ExitReason};
+use crate::{Capture, Transfer, ExitReason, Code};
 
 /// Basic account information.
 #[derive(Clone, Eq, PartialEq, Debug, Default)]
@@ -95,7 +95,7 @@ pub trait Backend {
 	/// Get account code size.
 	fn code_size(&self, address: H160) -> usize;
 	/// Get account code.
-	fn code(&self, address: H160) -> Vec<u8>;
+	fn code(&self, address: H160) -> Code;
 	/// Get storage value of address at index.
 	fn storage(&self, address: H160, index: U256) -> U256;
 

--- a/src/executor/stack.rs
+++ b/src/executor/stack.rs
@@ -5,7 +5,7 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use primitive_types::{U256, H256, H160};
 use sha3::{Keccak256, Digest};
 use crate::{ExitError, Stack, ExternalOpcode, Opcode, Capture, Handler, Transfer,
-			Context, CreateScheme, Runtime, ExitReason, ExitSucceed, Config};
+			Context, CreateScheme, Runtime, ExitReason, ExitSucceed, Config, Code};
 use crate::backend::{Log, Basic, Apply, Backend};
 //use crate::gasometer::{self, Gasometer};
 
@@ -404,7 +404,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 				}
 			} else  {
 				let code = substate.backend.code(address);
-				substate.account_mut(address).code = Some(code.clone());
+				substate.account_mut(address).code = Some((&code[..]).into());
 
 				if code.len() != 0 {
 					let _ = self.merge_fail(substate);
@@ -444,7 +444,7 @@ impl<'backend, 'config, B: Backend> StackExecutor<'backend, 'config, B> {
 		}
 
 		let mut runtime = Runtime::new(
-			init_code,
+			Code::Vec{ code: init_code },
 			Vec::new(),
 			context,
 			self.config,
@@ -672,9 +672,9 @@ impl<'backend, 'config, B: Backend> Handler for StackExecutor<'backend, 'config,
 		value
 	}
 
-	fn code(&self, address: H160) -> Vec<u8> {
+	fn code(&self, address: H160) -> Code {
 		self.state.get(&address).and_then(|v| {
-			v.code.clone()
+			v.code.clone().map(|code| Code::Vec{ code })
 		}).unwrap_or(self.backend.code(address))
 	}
 


### PR DESCRIPTION
Remove a copy of the contract code.

Limitations:
- Deploy still creates copies.
- Internal deploy also create copies. A lot of them.
- Calling contract that was deployed in the same transaction creates a copy.

Highly unsafe.