### PR TITLE
Optimize Vec<u8> serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,13 +17,14 @@ sha3 = { version = "0.8", default-features = false }
 rlp = { version = "0.4", default-features = false }
 primitive-types = { version = "0.7", default-features = false, features = ["rlp"] }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+serde_bytes = { version = "0.11.5", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"], optional = true }
 #ethereum = { version = "0.4", default-features = false }
 
 [features]
 default = ["std"]
 with-codec = ["codec", "evm-core/with-codec", "evm-runtime/with-codec", "primitive-types/codec"]
-with-serde = ["serde", "evm-core/with-serde", "evm-runtime/with-serde", "primitive-types/serde"]
+with-serde = ["serde", "serde_bytes", "evm-core/with-serde", "evm-runtime/with-serde", "primitive-types/serde"]
 std = ["evm-core/std", "evm-runtime/std", "sha3/std", "primitive-types/std", "serde/std", "codec/std", "log/std"]
 
 #[workspace]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -37,6 +37,7 @@ pub struct Log {
         /// topics
 	pub topics: Vec<H256>,
         /// data
+	#[serde(with = "serde_bytes")]
 	pub data: Bytes,
 }
 //pub use ethereum::Log;


### PR DESCRIPTION
Use `serde_bytes` to enable optimized handling of `Vec<u8>`.