### PR TITLE
#4 Optimize primitive_types serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ evm-core = { version = "0.18", path = "core", default-features = false }
 #evm-gasometer = { version = "0.18", path = "gasometer", default-features = false }
 evm-runtime = { version = "0.18", path = "runtime", default-features = false }
 sha3 = { version = "0.8", default-features = false }
-rlp = { version = "0.4", default-features = false }
-primitive-types = { version = "0.7", default-features = false, features = ["rlp"] }
+rlp = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive"], optional = true }
@@ -23,9 +22,9 @@ codec = { package = "parity-scale-codec", version = "1.3", default-features = fa
 
 [features]
 default = ["std"]
-with-codec = ["codec", "evm-core/with-codec", "evm-runtime/with-codec", "primitive-types/codec"]
-with-serde = ["serde", "serde_bytes", "evm-core/with-serde", "evm-runtime/with-serde", "primitive-types/serde"]
-std = ["evm-core/std", "evm-runtime/std", "sha3/std", "primitive-types/std", "serde/std", "codec/std", "log/std"]
+with-codec = ["codec", "evm-core/with-codec", "evm-runtime/with-codec"]
+with-serde = ["serde", "serde_bytes", "evm-core/with-serde", "evm-runtime/with-serde"]
+std = ["evm-core/std", "evm-runtime/std", "sha3/std", "serde/std", "codec/std", "log/std"]
 
 #[workspace]
 #members = [

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,8 +10,11 @@ edition = "2018"
 
 [dependencies]
 log = { version = "0.4", default-features = false }
-primitive-types = { version = "0.7", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
+fixed-hash = { version = "0.7", default-features = false, features = ["rustc-hex"] }
+uint = { version = "0.9", default-features = false }
+impl-rlp = { version = "0.3", default-features = false }
+rlp = { version = "0.5", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
 
@@ -20,6 +23,6 @@ hex = "0.4"
 
 [features]
 default = ["std"]
-with-codec = ["codec", "primitive-types/impl-codec"]
-with-serde = ["serde", "serde_bytes", "primitive-types/impl-serde"]
-std = ["primitive-types/std", "log/std", "codec/std", "serde/std"]
+with-codec = ["codec"]
+with-serde = ["serde", "serde_bytes"]
+std = ["log/std", "codec/std", "serde/std"]

--- a/core/src/code.rs
+++ b/core/src/code.rs
@@ -1,6 +1,6 @@
 use alloc::vec::Vec;
 use core::ops::Deref;
-use primitive_types::H160;
+use crate::H160;
 
 /// Contract code
 #[derive(Clone, Debug)]

--- a/core/src/eval/arithmetic.rs
+++ b/core/src/eval/arithmetic.rs
@@ -1,7 +1,6 @@
 use core::ops::Rem;
 use core::convert::TryInto;
-use primitive_types::{U256, U512};
-use crate::utils::I256;
+use crate::{utils::I256, U256, U512};
 
 pub fn div(op1: U256, op2: U256) -> U256 {
 	if op2 == U256::zero() {

--- a/core/src/eval/bitwise.rs
+++ b/core/src/eval/bitwise.rs
@@ -1,4 +1,4 @@
-use primitive_types::U256;
+use crate::U256;
 use crate::utils::{Sign, I256};
 
 pub fn slt(op1: U256, op2: U256) -> U256 {

--- a/core/src/eval/misc.rs
+++ b/core/src/eval/misc.rs
@@ -1,7 +1,6 @@
 use core::cmp::min;
-use primitive_types::{H256, U256};
 use super::Control;
-use crate::{Machine, ExitError, ExitSucceed, ExitFatal, ExitRevert};
+use crate::{Machine, ExitError, ExitSucceed, ExitFatal, ExitRevert, H256, U256};
 
 pub fn codesize(state: &mut Machine) -> Control {
 	let size = U256::from(state.code.len());

--- a/core/src/eval/mod.rs
+++ b/core/src/eval/mod.rs
@@ -5,8 +5,7 @@ mod bitwise;
 mod misc;
 
 use core::ops::{BitAnd, BitOr, BitXor};
-use primitive_types::U256;
-use crate::{ExitReason, ExitSucceed, ExitError, Machine, Opcode};
+use crate::{ExitReason, ExitSucceed, ExitError, Machine, Opcode, U256};
 
 #[derive(Clone, Eq, PartialEq, Debug)]
 pub enum Control {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -16,6 +16,7 @@ mod opcode;
 mod error;
 mod eval;
 mod utils;
+mod primitive_types;
 
 pub use crate::code::Code;
 pub use crate::memory::Memory;
@@ -23,6 +24,7 @@ pub use crate::stack::Stack;
 pub use crate::valids::Valids;
 pub use crate::opcode::Opcode;
 pub use crate::error::{Trap, Capture, ExitReason, ExitSucceed, ExitError, ExitRevert, ExitFatal};
+pub use crate::primitive_types::{H160, H256, U256, U512};
 
 use core::ops::Range;
 use alloc::vec::Vec;

--- a/core/src/primitive_types.rs
+++ b/core/src/primitive_types.rs
@@ -1,0 +1,174 @@
+use fixed_hash::{construct_fixed_hash, impl_fixed_hash_conversions};
+use uint::{construct_uint};
+
+
+construct_fixed_hash! {
+	/// Fixed-size uninterpreted hash type with 20 bytes (160 bits) size.
+	pub struct H160(20);
+}
+construct_fixed_hash! {
+	/// Fixed-size uninterpreted hash type with 32 bytes (256 bits) size.
+	pub struct H256(32);
+}
+
+impl_fixed_hash_conversions!(H256, H160);
+
+
+construct_uint! {
+	/// 256-bit unsigned integer.
+	pub struct U256(4);
+}
+
+construct_uint! {
+	/// 512-bit unsigned integer.
+	pub struct U512(8);
+}
+
+impl_rlp::impl_uint_rlp!(U256, 4);
+impl_rlp::impl_fixed_hash_rlp!(H160, 20);
+
+
+impl From<U256> for U512 {
+	fn from(value: U256) -> U512 {
+		let U256(ref arr) = value;
+		let mut ret = [0; 8];
+		ret[0] = arr[0];
+		ret[1] = arr[1];
+		ret[2] = arr[2];
+		ret[3] = arr[3];
+		U512(ret)
+	}
+}
+
+/// Error type for conversion.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Error {
+	/// Overflow encountered.
+	Overflow,
+}
+
+impl core::convert::TryFrom<U512> for U256 {
+	type Error = Error;
+
+	fn try_from(value: U512) -> Result<U256, Error> {
+		let U512(ref arr) = value;
+		if arr[4] | arr[5] | arr[6] | arr[7] != 0 {
+			return Err(Error::Overflow);
+		}
+		let mut ret = [0; 4];
+		ret[0] = arr[0];
+		ret[1] = arr[1];
+		ret[2] = arr[2];
+		ret[3] = arr[3];
+		Ok(U256(ret))
+	}
+}
+
+
+#[macro_export]
+macro_rules! impl_uint_serde {
+	($name: ident, $len: expr) => {
+		impl $crate::serde::Serialize for $name {
+			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+			where
+				S: $crate::serde::Serializer,
+			{
+				
+			}
+		}
+
+		impl<'de> $crate::serde::Deserialize<'de> for $name {
+			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+			where
+				D: $crate::serde::Deserializer<'de>,
+			{
+				
+			}
+		}
+	};
+}
+
+/// Add Serde serialization support to a fixed-sized hash type created by `construct_fixed_hash!`.
+#[macro_export]
+macro_rules! impl_fixed_hash_serde {
+	($name: ident) => {
+		impl serde::Serialize for $name {
+			fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+			where
+				S: serde::Serializer,
+			{
+				serializer.serialize_bytes(self.as_bytes())
+			}
+		}
+
+		impl<'de> serde::Deserialize<'de> for $name {
+			fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+			where
+				D: serde::Deserializer<'de>,
+			{
+				struct Visitor;
+				impl<'de> serde::de::Visitor<'de> for Visitor {
+					type Value = $name;
+
+					fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+						formatter.write_str(stringify!($name))
+					}
+
+					fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E>
+					{
+						let mut data = $name::default();
+						data.as_bytes_mut().copy_from_slice(v);
+
+						Ok(data)
+					}
+				}
+
+				deserializer.deserialize_bytes(Visitor)
+			}
+		}
+	};
+}
+
+#[cfg(feature = "with-serde")]
+impl_fixed_hash_serde!(H160);
+
+#[cfg(feature = "with-serde")]
+impl_fixed_hash_serde!(H256);
+
+
+impl serde::Serialize for U256 {
+	fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+	where
+		S: serde::Serializer,
+	{
+		let data: [u8; 32] = unsafe { core::mem::transmute_copy(self) };
+		serializer.serialize_bytes(&data)
+	}
+}
+
+impl<'de> serde::Deserialize<'de> for U256 {
+	fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+	where
+		D: serde::Deserializer<'de>,
+	{
+		struct Visitor;
+		impl<'de> serde::de::Visitor<'de> for Visitor {
+			type Value = U256;
+
+			fn expecting(&self, formatter: &mut core::fmt::Formatter) -> core::fmt::Result {
+				formatter.write_str("U256")
+			}
+
+			fn visit_bytes<E: serde::de::Error>(self, v: &[u8]) -> Result<Self::Value, E>
+			{
+				let mut data = [0u8; 32];
+				data.copy_from_slice(v);
+
+				let value: U256 = unsafe { core::mem::transmute(data) };
+				Ok(value)
+			}
+		}
+
+		deserializer.deserialize_bytes(Visitor)
+	}
+}

--- a/core/src/stack.rs
+++ b/core/src/stack.rs
@@ -1,12 +1,11 @@
-use primitive_types::{H256, U256};
 use alloc::vec::Vec;
-use crate::ExitError;
+use crate::{ExitError, H256, U256};
 
 #[cfg(feature = "with-serde")]
 mod serde_vec_u256 {
 	use serde::{Serializer, Deserializer, de};
-	use primitive_types::U256;
 	use alloc::{fmt, vec::Vec};
+	use crate::U256;
 
 	pub fn serialize<S: Serializer>(data: &Vec<U256>, serializer: S) -> Result<S::Ok, S::Error>
 	{

--- a/core/src/utils.rs
+++ b/core/src/utils.rs
@@ -1,6 +1,6 @@
 use core::ops::{Rem, Div};
 use core::cmp::Ordering;
-use primitive_types::U256;
+use crate::U256;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Sign {

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 
 [dependencies]
 evm-core = { version = "0.18", path = "../core", default-features = false }
-primitive-types = { version = "0.7", default-features = false }
 sha3 = { version = "0.8", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
@@ -18,6 +17,6 @@ serde_bytes = { version = "0.11.5", optional = true }
 
 [features]
 default = ["std"]
-with-codec = ["codec", "primitive-types/impl-codec"]
-with-serde = ["serde", "serde_bytes", "primitive-types/impl-serde"]
-std = ["evm-core/std", "primitive-types/std", "sha3/std"]
+with-codec = ["codec"]
+with-serde = ["serde", "serde_bytes"]
+std = ["evm-core/std", "sha3/std"]

--- a/runtime/src/context.rs
+++ b/runtime/src/context.rs
@@ -1,4 +1,4 @@
-use primitive_types::{H160, U256, H256};
+use crate::{H160, U256, H256};
 
 /// Create scheme.
 #[derive(Clone, Copy, Eq, PartialEq, Debug)]

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -1,8 +1,8 @@
 use core::cmp::min;
 use alloc::vec::Vec;
-use primitive_types::{H160, H256, U256};
 use crate::{Runtime, ExitError, Handler, Capture, Transfer, ExitReason,
-			CreateScheme, CallScheme, Context, ExitSucceed, ExitFatal};
+			CreateScheme, CallScheme, Context, ExitSucceed, ExitFatal,
+			H160, H256, U256};
 use super::Control;
 
 pub fn sha3<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {

--- a/runtime/src/handler.rs
+++ b/runtime/src/handler.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
-use primitive_types::{H160, H256, U256};
 use crate::{Capture, Stack, ExitError, Opcode,
-			CreateScheme, Context, Machine, ExitReason, Code};
+			CreateScheme, Context, Machine, ExitReason, Code,
+			H160, H256, U256};
 
 /// Transfer from source to target, with given value.
 #[derive(Clone, Debug)]

--- a/src/backend/memory.rs
+++ b/src/backend/memory.rs
@@ -1,11 +1,10 @@
 use alloc::vec::Vec;
 use alloc::collections::BTreeMap;
 use core::convert::Infallible;
-use primitive_types::{H160, H256, U256};
 use sha3::{Digest, Keccak256};
 use super::{Basic, Backend, ApplyBackend, Apply, Log};
 use evm_runtime::CreateScheme;
-use crate::{Capture, Transfer, ExitReason, Code};
+use crate::{Capture, Transfer, ExitReason, Code, H160, H256, U256};
 
 /// Vivinity value of a memory backend.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -9,9 +9,8 @@ pub use self::memory::{MemoryBackend, MemoryVicinity, MemoryAccount};
 
 use alloc::vec::Vec;
 use core::convert::Infallible;
-use primitive_types::{H160, H256, U256};
 use evm_runtime::CreateScheme;
-use crate::{Capture, Transfer, ExitReason, Code};
+use crate::{Capture, Transfer, ExitReason, Code, H160, H256, U256};
 
 /// Basic account information.
 #[derive(Clone, Eq, PartialEq, Debug, Default)]

--- a/src/executor/stack.rs
+++ b/src/executor/stack.rs
@@ -2,9 +2,8 @@ use core::convert::Infallible;
 use core::cmp::min;
 use alloc::vec::Vec;
 use alloc::collections::{BTreeMap, BTreeSet};
-use primitive_types::{U256, H256, H160};
 use crate::{ExitError, Stack, Opcode, Capture, Handler, Transfer,
-			Context, CreateScheme, Runtime, ExitReason, ExitSucceed, Config, Code};
+			Context, CreateScheme, Runtime, ExitReason, ExitSucceed, Config, Code, U256, H256, H160};
 use crate::backend::{Log, Basic, Apply, Backend};
 //use crate::gasometer::{self, Gasometer};
 


### PR DESCRIPTION
Currently primitive_types are de/serialized from/to hex string. Conversion from hex is extremely slow and consumes too many instructions. We can't change how they are serialized in the primitive_types crate. Solution is to use our own implementation instead of external crate.

- Remove primitive_types dependency
- Implement H160, H256, U256, U512
- Add fast binary de/serialization of these types