### PR TITLE
Backport tracing from original evm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ codec = { package = "parity-scale-codec", version = "1.3", default-features = fa
 default = ["std"]
 with-codec = ["codec", "evm-core/with-codec", "evm-runtime/with-codec"]
 with-serde = ["serde", "serde_bytes", "evm-core/with-serde", "evm-runtime/with-serde"]
-std = ["evm-core/std", "evm-runtime/std", "sha3/std", "serde/std", "codec/std", "log/std"]
-
+std = ["evm-core/std", "evm-runtime/std", "evm-gasometer/std", "sha3/std", "serde/std", "codec/std", "log/std"]
+tracing = ["evm-runtime/tracing", "evm-gasometer/tracing"]
 #[workspace]
 #members = [
 #  "core",

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -68,6 +68,11 @@ impl Machine {
 	/// Mutable reference of machine memory.
 	pub fn memory_mut(&mut self) -> &mut Memory { &mut self.memory }
 
+        /// Return a reference of the program counter.
+        pub fn position(&self) -> &Result<usize, ExitReason> {
+                &self.position
+        }
+
 	/// Create a new machine with given code and data.
 	#[must_use]
 	pub fn new(

--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -49,6 +49,10 @@ impl Memory {
 		self.len() == 0
 	}
 
+        pub fn data(&self) -> &[u8] {
+            &self.data
+        }
+
 	/// Resize the memory, making it cover the memory region of `offset..(offset
 	/// + len)`, with 32 bytes as the step. If the length is zero, this function
 	/// does nothing.

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 evm-core = { version = "0.18", path = "../core", default-features = false }
 evm-runtime = { version = "0.18", path = "../runtime", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
+environmental = { version = "1.1.2", default-features = false, optional = true }
 
 [features]
 default = ["std"]
@@ -19,4 +20,8 @@ with-serde = ["serde", "evm-core/with-serde"]
 std = [
   "evm-core/std",
   "evm-runtime/std",
+  "environmental/std",
+]
+tracing = [
+  "environmental"
 ]

--- a/gasometer/Cargo.toml
+++ b/gasometer/Cargo.toml
@@ -15,7 +15,7 @@ serde = { version = "1.0", default-features = false, features = ["derive"], opti
 
 [features]
 default = ["std"]
-with-serde = ["serde"]
+with-serde = ["serde", "evm-core/with-serde"]
 std = [
   "evm-core/std",
   "evm-runtime/std",

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -12,6 +12,22 @@
 #![cfg_attr(not(feature = "tracing"), forbid(unused_imports))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+#[cfg(feature = "tracing")]
+pub mod tracing;
+
+#[cfg(feature = "tracing")]
+macro_rules! event {
+	($x:expr) => {
+		use crate::tracing::Event::*;
+		$x.emit();
+	}
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! event {
+	($x:expr) => { }
+}
+
 mod consts;
 mod costs;
 mod memory;
@@ -19,8 +35,6 @@ mod utils;
 
 use evm_core::{ExitError, Opcode, Stack, H160, H256, U256};
 use evm_runtime::{CONFIG, Handler};
-
-pub mod tracing;
 
 macro_rules! try_or_fail {
 	( $inner:expr, $e:expr ) => (
@@ -32,6 +46,14 @@ macro_rules! try_or_fail {
 			},
 		}
 	)
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct Snapshot {
+    pub gas_limit: u64,
+    pub memory_gas: u64,
+	pub used_gas: u64,
+	pub refunded_gas: i64,
 }
 
 /// EVM gasometer.
@@ -114,10 +136,10 @@ impl Gasometer {
 		&mut self,
 		cost: u64
 	) -> Result<(), ExitError> {
-		tracing::Event::RecordCost {
+		event!(RecordCost {
 			cost,
 			snapshot: self.snapshot()?,
-		}.emit();
+		});
 
 		let all_gas_cost = self.total_used_gas() + cost;
 		if self.gas_limit < all_gas_cost {
@@ -134,10 +156,10 @@ impl Gasometer {
 		&mut self,
 		refund: i64,
 	) -> Result<(), ExitError> {
-		tracing::Event::RecordRefund {
+		event!(RecordRefund {
 			refund,			
 			snapshot: self.snapshot()?,
-		}.emit();
+		});
 
 		self.inner_mut()?.refunded_gas += refund;
 		Ok(())
@@ -169,12 +191,12 @@ impl Gasometer {
 		let gas_refund = self.inner_mut()?.gas_refund(cost.clone());
 		let used_gas = self.inner_mut()?.used_gas;
 
-		tracing::Event::RecordDynamicCost {
+		event!(RecordDynamicCost {
 			gas_cost,
 			memory_gas,
 			gas_refund, 
 			snapshot: self.snapshot()?,
-		}.emit();
+		});
 
 		let all_gas_cost = memory_gas + used_gas + gas_cost;
 		if self.gas_limit < all_gas_cost {
@@ -197,10 +219,10 @@ impl Gasometer {
 		&mut self,
 		stipend: u64,
 	) -> Result<(), ExitError> {
-		tracing::Event::RecordStipend {
+		event!(RecordStipend {
 			stipend,
 			snapshot: self.snapshot()?,
-		}.emit();
+		});
 
 		self.inner_mut()?.used_gas -= stipend;
 		Ok(())
@@ -224,10 +246,10 @@ impl Gasometer {
 			},
 		};
 
-		tracing::Event::RecordTransaction {
+		event!(RecordTransaction {
 			cost: gas_cost,
 			snapshot: self.snapshot()?,
-		}.emit();
+		});
 
 		if self.gas() < gas_cost {
 			self.inner = Err(ExitError::OutOfGas);
@@ -238,11 +260,11 @@ impl Gasometer {
 		Ok(())
 	}
 
-	fn snapshot(&self) -> Result<tracing::Snapshot, ExitError> {
+	pub fn snapshot(&self) -> Result<Snapshot, ExitError> {
 		let inner = self.inner.as_ref().map_err(|e| e.clone())?;
-		Ok(tracing::Snapshot {
+		Ok(Snapshot {
 			gas_limit: self.gas_limit,
-			memory_gas: inner.memory_gas,
+			memory_gas: inner.memory_cost,
 			used_gas: inner.used_gas,
 			refunded_gas: inner.refunded_gas,
 		})

--- a/gasometer/src/lib.rs
+++ b/gasometer/src/lib.rs
@@ -1,7 +1,7 @@
 //! EVM gasometer.
 
 #![deny(warnings)]
-#![forbid(unsafe_code, unused_variables, unused_imports)]
+#![forbid(unsafe_code, unused_variables)]
 #![deny(clippy::all, clippy::pedantic, clippy::nursery)]
 #![allow(
 	clippy::module_name_repetitions,
@@ -9,6 +9,7 @@
 	clippy::missing_panics_doc
 )]
 
+#![cfg_attr(not(feature = "tracing"), forbid(unused_imports))]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 mod consts;

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -1,7 +1,7 @@
 //! Allows to listen to gasometer events.
 
 #[cfg(feature = "tracing")]
-environmental::environmental!(hook: dyn EventListener + 'static);
+environmental::environmental!(listener: dyn EventListener + 'static);
 
 #[cfg(feature = "tracing")]
 pub trait EventListener {
@@ -27,7 +27,7 @@ pub enum Event {
 impl Event {
     #[cfg(feature = "tracing")]
     pub(crate) fn emit(self) {
-        hook::with(|hook| hook.event(self));
+        listener::with(|listener| listener.event(self));
     }
 
     #[cfg(not(feature = "tracing"))]
@@ -39,8 +39,8 @@ impl Event {
 /// Run closure with provided listener.
 #[cfg(feature = "tracing")]
 pub fn using<R, F: FnOnce() -> R>(
-    listener: &mut (dyn EventListener + 'static),
+    new: &mut (dyn EventListener + 'static),
     f: F
 ) -> R {
-    hook::using(listener, f)
+    listener::using(new, f)
 }

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -12,16 +12,43 @@ pub trait EventListener {
 }
 
 #[derive(Debug, Copy, Clone)]
+pub struct Snapshot {
+    pub gas_limit: u64,
+    pub memory_gas: u64,
+	pub used_gas: u64,
+	pub refunded_gas: i64,
+}
+
+impl Snapshot {
+    pub fn gas(&self) -> u64 {
+        self.gas_limit - self.used_gas - self.memory_gas
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
 pub enum Event {
-    RecordCost(u64),
-    RecordRefund(i64),
-    RecordStipend(u64),
+    RecordCost {
+        cost: u64,
+        snapshot: Snapshot,
+    },
+    RecordRefund {
+        refund: i64,
+        snapshot: Snapshot,
+    },
+    RecordStipend {
+        stipend: u64,
+        snapshot: Snapshot,
+    },
     RecordDynamicCost {
         gas_cost: u64,
         memory_gas: u64,
         gas_refund: i64,
+        snapshot: Snapshot,
     },
-    RecordTransaction(u64),
+    RecordTransaction {
+        cost: u64,
+        snapshot: Snapshot,
+    },
 }
 
 impl Event {

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -1,0 +1,46 @@
+//! Allows to listen to gasometer events.
+
+#[cfg(feature = "tracing")]
+environmental::environmental!(hook: dyn EventListener + 'static);
+
+#[cfg(feature = "tracing")]
+pub trait EventListener {
+    fn event(
+        &mut self,
+        event: Event
+    );
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Event {
+    RecordCost(u64),
+    RecordRefund(i64),
+    RecordStipend(u64),
+    RecordDynamicCost {
+        gas_cost: u64,
+        memory_gas: u64,
+        gas_refund: i64,
+    },
+    RecordTransaction(u64),
+}
+
+impl Event {
+    #[cfg(feature = "tracing")]
+    pub(crate) fn emit(self) {
+        hook::with(|hook| hook.event(self));
+    }
+
+    #[cfg(not(feature = "tracing"))]
+    pub(crate) fn emit(self) {
+        // no op.
+    }
+}
+
+/// Run closure with provided listener.
+#[cfg(feature = "tracing")]
+pub fn using<R, F: FnOnce() -> R>(
+    listener: &mut (dyn EventListener + 'static),
+    f: F
+) -> R {
+    hook::using(listener, f)
+}

--- a/gasometer/src/tracing.rs
+++ b/gasometer/src/tracing.rs
@@ -1,22 +1,14 @@
 //! Allows to listen to gasometer events.
 
-#[cfg(feature = "tracing")]
+use super::Snapshot;
+
 environmental::environmental!(listener: dyn EventListener + 'static);
 
-#[cfg(feature = "tracing")]
 pub trait EventListener {
     fn event(
         &mut self,
         event: Event
     );
-}
-
-#[derive(Debug, Copy, Clone)]
-pub struct Snapshot {
-    pub gas_limit: u64,
-    pub memory_gas: u64,
-	pub used_gas: u64,
-	pub refunded_gas: i64,
 }
 
 impl Snapshot {
@@ -52,19 +44,12 @@ pub enum Event {
 }
 
 impl Event {
-    #[cfg(feature = "tracing")]
     pub(crate) fn emit(self) {
         listener::with(|listener| listener.event(self));
-    }
-
-    #[cfg(not(feature = "tracing"))]
-    pub(crate) fn emit(self) {
-        // no op.
     }
 }
 
 /// Run closure with provided listener.
-#[cfg(feature = "tracing")]
 pub fn using<R, F: FnOnce() -> R>(
     new: &mut (dyn EventListener + 'static),
     f: F

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -14,9 +14,13 @@ sha3 = { version = "0.8", default-features = false }
 codec = { package = "parity-scale-codec", version = "1.3", default-features = false, features = ["derive", "full"], optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 serde_bytes = { version = "0.11.5", optional = true }
+environmental = { version = "1.1.2", default-features = false, optional = true}
 
 [features]
 default = ["std"]
 with-codec = ["codec"]
 with-serde = ["serde", "serde_bytes"]
-std = ["evm-core/std", "sha3/std"]
+std = ["evm-core/std", "sha3/std", "environmental/std"]
+tracing = [
+  "environmental"
+]

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -1,6 +1,6 @@
 use core::cmp::min;
 use alloc::vec::Vec;
-use crate::{Runtime, ExitError, Handler, Capture, Transfer, ExitReason,
+use crate::{tracing, Runtime, ExitError, Handler, Capture, Transfer, ExitReason,
 			CreateScheme, CallScheme, Context, ExitSucceed, ExitFatal,
 			H160, H256, U256};
 use super::Control;
@@ -177,13 +177,27 @@ pub fn gaslimit<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 
 pub fn sload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	pop_u256!(runtime, index);
-	push_u256!(runtime, handler.storage(runtime.context.address, index));
+	let value = handler.storage(runtime.context.address, index);
+	push_u256!(runtime, value);
+
+	tracing::Event::SLoad {
+		address: runtime.context.address,
+		index,
+		value
+	}.emit();
 
 	Control::Continue
 }
 
 pub fn sstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
 	pop_u256!(runtime, index, value);
+
+	tracing::Event::SStore {
+		address: runtime.context.address,
+		index,
+		value
+	}.emit();
+
 	match handler.set_storage(runtime.context.address, index, value) {
 		Ok(()) => Control::Continue,
 		Err(e) => Control::Exit(e.into()),

--- a/runtime/src/eval/system.rs
+++ b/runtime/src/eval/system.rs
@@ -1,6 +1,6 @@
 use core::cmp::min;
 use alloc::vec::Vec;
-use crate::{tracing, Runtime, ExitError, Handler, Capture, Transfer, ExitReason,
+use crate::{Runtime, ExitError, Handler, Capture, Transfer, ExitReason,
 			CreateScheme, CallScheme, Context, ExitSucceed, ExitFatal,
 			H160, H256, U256};
 use super::Control;
@@ -180,11 +180,11 @@ pub fn sload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 	let value = handler.storage(runtime.context.address, index);
 	push_u256!(runtime, value);
 
-	tracing::Event::SLoad {
+	event!(SLoad {
 		address: runtime.context.address,
 		index,
 		value
-	}.emit();
+	});
 
 	Control::Continue
 }
@@ -192,11 +192,11 @@ pub fn sload<H: Handler>(runtime: &mut Runtime, handler: &H) -> Control<H> {
 pub fn sstore<H: Handler>(runtime: &mut Runtime, handler: &mut H) -> Control<H> {
 	pop_u256!(runtime, index, value);
 
-	tracing::Event::SStore {
+	event!(SStore {
 		address: runtime.context.address,
 		index,
 		value
-	}.emit();
+	});
 
 	match handler.set_storage(runtime.context.address, index, value) {
 		Ok(()) => Control::Continue,

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -19,7 +19,7 @@ pub mod tracing;
 macro_rules! event {
 	($x:expr) => {
 		use crate::tracing::Event::*;
-		$x.emit();
+                crate::tracing::with(|listener| listener.event($x));
 	}
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -8,15 +8,16 @@
 	clippy::missing_errors_doc,
 	clippy::missing_panics_doc
 )]
-
 #![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
+
 
 mod eval;
 mod context;
 mod interrupt;
 mod handler;
+pub mod tracing;
 
 pub use evm_core::*;
 
@@ -30,6 +31,13 @@ use alloc::vec::Vec;
 macro_rules! step {
 	( $self:expr, $handler:expr, $return:tt $($err:path)?; $($ok:path)? ) => ({
 		if let Some((opcode, stack)) = $self.machine.inspect() {
+			tracing::Event::Step {
+				context: &$self.context,
+				opcode,
+				stack,
+				memory: $self.machine.memory()
+			}.emit();
+			
 			match $handler.pre_validate(&$self.context, opcode, stack) {
 				Ok(()) => (),
 				Err(e) => {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -76,6 +76,8 @@ macro_rules! step {
 		event!(StepResult {
 			result: &result,
 			return_value: &$self.machine.return_value(),
+                        stack: $self.machine.stack(),
+                        memory: $self.machine.memory(),
 		});
 
 		match result {

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -34,6 +34,7 @@ macro_rules! step {
 			tracing::Event::Step {
 				context: &$self.context,
 				opcode,
+				position: $self.machine.position(),
 				stack,
 				memory: $self.machine.memory()
 			}.emit();
@@ -56,8 +57,12 @@ macro_rules! step {
 		}
 
 		let result = $self.machine.step();
+		let return_value = $self.machine.return_value();
 
-		tracing::Event::StepResult(&result).emit();
+		tracing::Event::StepResult {
+			result: &result,
+			return_value: &return_value,
+		}.emit();
 
 		match result {
 			Ok(()) => $($ok)?(()),

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -1,7 +1,7 @@
 //! Runtime layer for EVM.
 
 #![deny(warnings)]
-#![forbid(unsafe_code, unused_variables, unused_imports)]
+#![forbid(unsafe_code, unused_variables)]
 #![deny(clippy::all, clippy::pedantic, clippy::nursery)]
 #![allow(
 	clippy::module_name_repetitions,
@@ -9,6 +9,7 @@
 	clippy::missing_panics_doc
 )]
 #![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(feature = "tracing"), forbid(unused_imports))]
 
 extern crate alloc;
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -55,7 +55,11 @@ macro_rules! step {
 			},
 		}
 
-		match $self.machine.step() {
+		let result = $self.machine.step();
+
+		tracing::Event::StepResult(&result).emit();
+
+		match result {
 			Ok(()) => $($ok)?(()),
 			Err(Capture::Exit(e)) => {
 				$self.status = Err(e.clone());

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -12,12 +12,26 @@
 
 extern crate alloc;
 
+#[cfg(feature = "tracing")]
+pub mod tracing;
+
+#[cfg(feature = "tracing")]
+macro_rules! event {
+	($x:expr) => {
+		use crate::tracing::Event::*;
+		$x.emit();
+	}
+}
+
+#[cfg(not(feature = "tracing"))]
+macro_rules! event {
+	($x:expr) => {}
+}
 
 mod eval;
 mod context;
 mod interrupt;
 mod handler;
-pub mod tracing;
 
 pub use evm_core::*;
 
@@ -31,13 +45,13 @@ use alloc::vec::Vec;
 macro_rules! step {
 	( $self:expr, $handler:expr, $return:tt $($err:path)?; $($ok:path)? ) => ({
 		if let Some((opcode, stack)) = $self.machine.inspect() {
-			tracing::Event::Step {
+			event!(Step {
 				context: &$self.context,
 				opcode,
 				position: $self.machine.position(),
 				stack,
 				memory: $self.machine.memory()
-			}.emit();
+			});
 			
 			match $handler.pre_validate(&$self.context, opcode, stack) {
 				Ok(()) => (),
@@ -57,12 +71,11 @@ macro_rules! step {
 		}
 
 		let result = $self.machine.step();
-		let return_value = $self.machine.return_value();
 
-		tracing::Event::StepResult {
+		event!(StepResult {
 			result: &result,
-			return_value: &return_value,
-		}.emit();
+			return_value: &$self.machine.return_value(),
+		});
 
 		match result {
 			Ok(()) => $($ok)?(()),

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -1,0 +1,58 @@
+//! Allows to listen to runtime events.
+
+use crate::{Context, Opcode, Stack, Memory};
+use crate::{H160, U256};
+
+
+
+#[cfg(feature = "tracing")]
+environmental::environmental!(hook: dyn EventListener + 'static);
+
+#[cfg(feature = "tracing")]
+pub trait EventListener {
+    fn event(
+        &mut self,
+        event: Event
+    );
+}
+
+#[derive(Debug, Copy, Clone)]
+pub enum Event<'a> {
+    Step {
+        context: &'a Context,
+        opcode: Opcode,
+        stack: &'a Stack,
+        memory: &'a Memory
+    },
+    SLoad {
+        address: H160,
+        index: U256,
+        value: U256
+    },
+    SStore {
+        address: H160,
+        index: U256,
+        value: U256
+    },
+}
+
+impl<'a> Event<'a> {
+    #[cfg(feature = "tracing")]
+    pub(crate) fn emit(self) {
+        hook::with(|hook| hook.event(self));
+    }
+
+    #[cfg(not(feature = "tracing"))]
+    pub(crate) fn emit(self) {
+        // no op.
+    }
+}
+
+/// Run closure with provided listener.
+#[cfg(feature = "tracing")]
+pub fn using<R, F: FnOnce() -> R>(
+    listener: &mut (dyn EventListener + 'static),
+    f: F
+) -> R {
+    hook::using(listener, f)
+}

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -3,9 +3,8 @@
 use crate::{Context, Opcode, Stack, Memory, Capture, ExitReason, Trap};
 use crate::{H160, U256};
 
-
 #[cfg(feature = "tracing")]
-environmental::environmental!(hook: dyn EventListener + 'static);
+environmental::environmental!(listener: dyn EventListener + 'static);
 
 #[cfg(feature = "tracing")]
 pub trait EventListener {
@@ -20,10 +19,14 @@ pub enum Event<'a> {
     Step {
         context: &'a Context,
         opcode: Opcode,
+        position: &'a Result<usize, ExitReason>,
         stack: &'a Stack,
         memory: &'a Memory
     },
-    StepResult (&'a Result<(), Capture<ExitReason, Trap>>),
+    StepResult {
+        result: &'a Result<(), Capture<ExitReason, Trap>>,
+        return_value: &'a [u8],
+    },
     SLoad {
         address: H160,
         index: U256,
@@ -39,7 +42,7 @@ pub enum Event<'a> {
 impl<'a> Event<'a> {
     #[cfg(feature = "tracing")]
     pub(crate) fn emit(self) {
-        hook::with(|hook| hook.event(self));
+        listener::with(|listener| listener.event(self));
     }
 
     #[cfg(not(feature = "tracing"))]
@@ -51,8 +54,8 @@ impl<'a> Event<'a> {
 /// Run closure with provided listener.
 #[cfg(feature = "tracing")]
 pub fn using<R, F: FnOnce() -> R>(
-    listener: &mut (dyn EventListener + 'static),
+    new: &mut (dyn EventListener + 'static),
     f: F
 ) -> R {
-    hook::using(listener, f)
+    listener::using(new, f)
 }

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -3,10 +3,8 @@
 use crate::{Context, Opcode, Stack, Memory, Capture, ExitReason, Trap};
 use crate::{H160, U256};
 
-#[cfg(feature = "tracing")]
 environmental::environmental!(listener: dyn EventListener + 'static);
 
-#[cfg(feature = "tracing")]
 pub trait EventListener {
     fn event(
         &mut self,
@@ -40,19 +38,12 @@ pub enum Event<'a> {
 }
 
 impl<'a> Event<'a> {
-    #[cfg(feature = "tracing")]
     pub(crate) fn emit(self) {
         listener::with(|listener| listener.event(self));
-    }
-
-    #[cfg(not(feature = "tracing"))]
-    pub(crate) fn emit(self) {
-        // no op.
     }
 }
 
 /// Run closure with provided listener.
-#[cfg(feature = "tracing")]
 pub fn using<R, F: FnOnce() -> R>(
     new: &mut (dyn EventListener + 'static),
     f: F

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -1,8 +1,7 @@
 //! Allows to listen to runtime events.
 
-use crate::{Context, Opcode, Stack, Memory};
+use crate::{Context, Opcode, Stack, Memory, Capture, ExitReason, Trap};
 use crate::{H160, U256};
-
 
 
 #[cfg(feature = "tracing")]
@@ -24,6 +23,7 @@ pub enum Event<'a> {
         stack: &'a Stack,
         memory: &'a Memory
     },
+    StepResult (&'a Result<(), Capture<ExitReason, Trap>>),
     SLoad {
         address: H160,
         index: U256,

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -37,12 +37,6 @@ pub enum Event<'a> {
     },
 }
 
-impl<'a> Event<'a> {
-    pub(crate) fn emit(self) {
-        listener::with(|listener| listener.event(self));
-    }
-}
-
 /// Run closure with provided listener.
 pub fn using<R, F: FnOnce() -> R>(
     new: &mut (dyn EventListener + 'static),
@@ -50,3 +44,8 @@ pub fn using<R, F: FnOnce() -> R>(
 ) -> R {
     listener::using(new, f)
 }
+
+pub(crate) fn with<F: FnOnce(&mut (dyn EventListener + 'static))>(f: F) {
+       listener::with(f);
+}
+

--- a/runtime/src/tracing.rs
+++ b/runtime/src/tracing.rs
@@ -24,6 +24,8 @@ pub enum Event<'a> {
     StepResult {
         result: &'a Result<(), Capture<ExitReason, Trap>>,
         return_value: &'a [u8],
+        stack: &'a Stack,
+        memory: &'a Memory
     },
     SLoad {
         address: H160,


### PR DESCRIPTION
Implement tracing infrastructure in evm by backporting changes from original `rust-evm` project.