### PR TITLE
Skip setting memory value if the value vec is empty

### DIFF
--- a/core/src/memory.rs
+++ b/core/src/memory.rs
@@ -116,6 +116,10 @@ impl Memory {
 		value: &[u8],
 		target_size: Option<usize>
 	) -> Result<(), ExitFatal> {
+		if value.is_empty() {
+			return Ok(())
+		}
+		
 		let target_size = target_size.unwrap_or(value.len());
 
 		if offset.checked_add(target_size).map_or(true, |pos| pos > self.limit)


### PR DESCRIPTION
Port the fix for DoS https://rustsec.org/advisories/RUSTSEC-2021-0066